### PR TITLE
Major refactor of power up board display implemenation

### DIFF
--- a/HumanPlayer.cpp
+++ b/HumanPlayer.cpp
@@ -99,11 +99,6 @@ void HumanPlayer::print()
     playerBoard.PrintMap();
 }
 
-void HumanPlayer::printPowerUps()
-{
-  playerBoard.PrintPowerUpMap();
-}
-
 int HumanPlayer::getHits()
 {
   return num_hits;

--- a/HumanPlayer.h
+++ b/HumanPlayer.h
@@ -10,7 +10,6 @@ class HumanPlayer : public PlayerInterface
 {
     private:
     Board playerBoard;//access the board object
-
     string marks;
     int marked;//ships that are marked
     int unmark;//ships that are unmarked
@@ -39,13 +38,6 @@ class HumanPlayer : public PlayerInterface
  *@post print the map in board object
  *@param None  */
     void print();
-
-    /** Default constructor
-    *@pre none
-    *@post return true if all ships are marked, false otherwise
-    *@param None  */
-
-    void printPowerUps();
 
 /** Default constructor
  *@pre none

--- a/battleExec.cpp
+++ b/battleExec.cpp
@@ -38,6 +38,26 @@ void Executive::runPvP()
 
   CalculateWinHits(ship_num);//ship_num is inputted by user, this function is called to find total hits to win game
 
+  /*
+    Determine number of powerups desired for the game.
+  */
+  cout << "Enter number of power ups desired (Up to 64 allowed): ";
+  cin >> numPowerUps;
+  while(1)
+  {
+    if(cin.fail())
+    {
+      cin.clear();
+      cin.ignore(numeric_limits<streamsize>::max(),'\n');
+      cout << "\n\nFor number of power ups, please enter a number between 0 and 64: "; //if not an int, must try again.
+      cin >> numPowerUps;
+    }
+    else
+    {
+      break;
+    }
+  }
+
   HumanPlayer player1; //creates player 1 with the number of ships obtained from input
   player1.setNum(ship_num);
   cout<<"\n---------PLAYER 1----------\n\n";
@@ -168,6 +188,14 @@ void Executive::runPvP()
   cin >> dummy;
   ClearScreen();
 
+  /*
+    Create powerup board here
+  */
+    powerUpGenerator();
+  /*
+
+  */
+
   while(player1.getHits() != win_hits && player2.getHits() != win_hits)   /////add while loop to check win condition
   {   string x;
 
@@ -175,7 +203,7 @@ void Executive::runPvP()
 
         player1.printHidden();
         player1.print();
-
+        displayPowerUps();
 
       cout <<"\nEnter attack coordinates (A-H),(1-8) (i.e. A1): ";
       cin >>x;
@@ -227,6 +255,7 @@ void Executive::runPvP()
 
       player2.printHidden();
       player2.print();
+      displayPowerUps();
 
       cout <<"\nEnter attack coordinates (A-H),(1-8) (i.e. A1): ";
       cin >>x;
@@ -557,4 +586,65 @@ void Executive::setAIDifficulty(AI& someAI)
   cin >> AIDifficulty;
 
   someAI.setDifficulty(AIDifficulty);
+}
+
+void Executive::powerUpGenerator()
+{
+  //create an initial array of position values to be later shuffled
+  powerUps = new char*[8];
+  for(int i = 0; i < 8; i++)
+  {
+    powerUps[i] = new char[8];
+  }
+  for(int i = 0; i < 8; i++)
+  {
+    for(int j = 0; j < 8; j++)
+    {
+      powerUps[i][j] = '~';
+    }
+  }
+
+  int* powerUpPositions = new int[64];
+  for(int i = 0; i < 64; i++)
+  {
+    powerUpPositions[i] = i;
+  }
+
+  //Shuffle the powerUpPositions array;
+  shuffleArray(powerUpPositions, 64);
+
+  int r = 0;
+  for(int i = 0; i < numPowerUps; i++)
+  {
+    r = powerUpPositions[i];
+    int x = r / 8;
+    int y = r % 8;
+    powerUps[x][y] = 'x';
+  }
+}
+
+void Executive::shuffleArray(int powerUpPos[], int size)
+{
+  srand(time(0));  // Initialize random number generator.
+  for(int i = 0; i < (size * 10); i++)
+  {
+    int index1 = (rand() % size);
+    int index2 = (rand() % size);
+    int placeHolder = powerUpPos[index1];
+    powerUpPos[index1] = powerUpPos[index2];
+    powerUpPos[index2] = placeHolder;
+  }
+}
+
+void Executive::displayPowerUps()
+{
+  cout <<"\n       Power Ups: \n\n";
+  for(int i = 0; i < 8; i++) {
+    if(i == 0) cout << "   A  B  C  D  E  F  G  H\n";
+    for(int j = 0; j < 8; j++) {
+      if(j == 0) cout << i+1;
+       cout << "  " << powerUps[i][j];
+    }
+    cout << '\n';
+  }
 }

--- a/battleExec.h
+++ b/battleExec.h
@@ -90,9 +90,19 @@ public:
 
     void setAIDifficulty(AI& someAI);
 
+    /** Random powerup location generator
+   @pre powerUps 2D array is already built and initialized.
+   @post powerUps 2D array will have random locations marked for the power ups.
+   @param None  */
+    void powerUpGenerator();
+
+    void shuffleArray(int powerUpPos[], int size);
+
+    void displayPowerUps();
+
 
 private:
-  
+
       /** funtion that runs a player versus player game
       *@pre player_num == 2
       *@post runs the PvP game
@@ -114,5 +124,8 @@ private:
 
       string location; //row and column on the map
       int dir; //direction that the ship faces
+
+      int numPowerUps = 0;
+      char** powerUps = nullptr;
 };
 #endif

--- a/board.cpp
+++ b/board.cpp
@@ -18,14 +18,13 @@ Board::Board() {
     for(int j = 0; j < 8; j++) {
       grid[i][j] = '~';
       map[i][j] = '~';
-      powerUps[i][j] = '~';
-      powerUpGenerator();
     }
   }
-
+  //powerUpGenerator();
   shipsRemaining = 0;
 }
 
+/*
 void Board::powerUpGenerator()
 {
   //create an initial array of position values to be later shuffled
@@ -50,6 +49,11 @@ void Board::powerUpGenerator()
   //int y = i % 8;
 }
 
+void Board::setNumPowerUps(int n)
+{
+  numPowerUps = n;
+}
+
 void Board::shuffleArray(int powerUpPos[], int size)
 {
   srand(time(0));  // Initialize random number generator.
@@ -62,6 +66,7 @@ void Board::shuffleArray(int powerUpPos[], int size)
     powerUpPos[index2] = placeHolder;
   }
 }
+*/
 
 void Board::PrintMap() {
   shipsRemaining = 0;
@@ -78,9 +83,10 @@ void Board::PrintMap() {
   cout<< "\n       Ship Legend:\n         a = Patrol Boat\n         b = Submarine\n         c = Destroyer\n         d = Battleship\n         e = Carrier\n\n";
   statusReport();
 
-  PrintPowerUpMap();
+  //PrintPowerUpMap();
 }
 
+/*
 void Board::PrintPowerUpMap() {
   cout <<"\n       Power Ups: \n\n";
   for(int i = 0; i < 8; i++) {
@@ -92,7 +98,7 @@ void Board::PrintPowerUpMap() {
     cout << '\n';
   }
 }
-
+*/
 
 void Board::statusReport() {
   shipsRemaining = 0;

--- a/board.h
+++ b/board.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <ctime>    // For time()
 #include <cstdlib>  // For srand() and rand()
+#include <limits>
 
 using namespace std;
 
@@ -28,17 +29,7 @@ public:
  @post
  @param None  */
   Board();
-
-  /** Random powerup location generator
- @pre powerUps 2D array is already built and initialized.
- @post powerUps 2D array will have random locations marked for the power ups.
- @param None  */
-void powerUpGenerator();
-
-
-
-
-
+  
   /** notify player of all active ships
  *@pre PrintMap is called
  *@post statusReport will notify the player of any ships active during gameplay
@@ -94,7 +85,7 @@ void powerUpGenerator();
  *@pre
  *@post
  *@param None  */
-  void PrintPowerUpMap();
+  //void PrintPowerUpMap();
 
   /** updates the hidden board to reflect players attack
  *@pre
@@ -116,7 +107,9 @@ void powerUpGenerator();
   *@param  int powerUpPos[] - the array to be shuffled so random number can be selected without repeats.
            int size - the size of the array to be shuffled.
   */
-  void shuffleArray(int powerUpPos[], int size);
+  //void shuffleArray(int powerUpPos[], int size);
+  //void setNumPowerUps(int n);
+
 
 
 private:
@@ -127,8 +120,7 @@ private:
   remainings = is current ship still afloat
   shipsRemaining = number of ships remaining on the personal board during gameplay
   */
-  char powerUps[8][8];
-  int numPowerUps = 10;
+  //char powerUps[8][8];
   char grid[8][8];
   char map[8][8];
   bool aActive, bActive, cActive, dActive, eActive;


### PR DESCRIPTION
This was a major refactor of the display implementation from the last commit. 
The code was originally using the board class to display the power ups. 

Problem: when each player was in ship-placement mode, each could determine how many power ups they could have. Player one could choose 30 power ups while player two could choose 64. 

Now both players must select at the beginning of the game how many power ups each will have a chance to get.

The power up board is created in the executive class and is visible to both players. 

A flag will be added to the class to enable or disable the display.
As players play, the board will be usable by both players, meaning if one player lands a shot on a power up, that spot would no longer be usable after that point by either players.