### PR TITLE
Removed the dynamic array for powerUps

### DIFF
--- a/battleExec.cpp
+++ b/battleExec.cpp
@@ -591,11 +591,6 @@ void Executive::setAIDifficulty(AI& someAI)
 void Executive::powerUpGenerator()
 {
   //create an initial array of position values to be later shuffled
-  powerUps = new char*[8];
-  for(int i = 0; i < 8; i++)
-  {
-    powerUps[i] = new char[8];
-  }
   for(int i = 0; i < 8; i++)
   {
     for(int j = 0; j < 8; j++)

--- a/battleExec.h
+++ b/battleExec.h
@@ -126,6 +126,6 @@ private:
       int dir; //direction that the ship faces
 
       int numPowerUps = 0;
-      char** powerUps = nullptr;
+      char powerUps [8][8];
 };
 #endif


### PR DESCRIPTION
Originally, the HumanPlayer objects were given access to the power ups array in the executive class via pointers. No longer needed.